### PR TITLE
Fix OrderStatus label mapping

### DIFF
--- a/packages/ticket_sidebar/src/components/styled/Indicator.tsx
+++ b/packages/ticket_sidebar/src/components/styled/Indicator.tsx
@@ -40,17 +40,17 @@ const Indicator = styled.div<{ $type: OrderStatus }>`
           background-color: var(--zd-color-green-600);
         `
       }
-      case 'cancelled_by_customer': {
+      case 'cancelled-by-customer': {
         return css`
           background-color: var(--zd-color-secondary-crimson-600);
         `
       }
-      case 'cancelled_by_system': {
+      case 'cancelled-by-system': {
         return css`
           background-color: var(--zd-color-secondary-crimson-600);
         `
       }
-      case 'user_unreachable': {
+      case 'user-unreachable': {
         return css`
           background-color: var(--zd-color-yellow-400);
         `

--- a/packages/ticket_sidebar/src/types.ts
+++ b/packages/ticket_sidebar/src/types.ts
@@ -17,9 +17,9 @@ export type OrderStatus =
   | 'prepared'
   | 'delivering'
   | 'delivered'
-  | 'cancelled_by_customer'
-  | 'cancelled_by_system'
-  | 'user_unreachable'
+  | 'cancelled-by-customer'
+  | 'cancelled-by-system'
+  | 'user-unreachable'
   | 'delayed'
 
 export type Order = {

--- a/packages/ticket_sidebar/src/utils.ts
+++ b/packages/ticket_sidebar/src/utils.ts
@@ -12,9 +12,9 @@ const STATUS_MAP = new Map<OrderStatus, string>([
   ['prepared', 'Prepared'],
   ['delivering', 'Delivering'],
   ['delivered', 'Delivered'],
-  ['cancelled_by_customer', 'Cancelled by customer'],
-  ['cancelled_by_system', 'Cancelled by system'],
-  ['user_unreachable', 'User unreachable'],
+  ['cancelled-by-customer', 'Cancelled by customer'],
+  ['cancelled-by-system', 'Cancelled by system'],
+  ['user-unreachable', 'User unreachable'],
   ['delayed', 'Delayed'],
 ])
 export const getOrderStatus = (status: OrderStatus) => {


### PR DESCRIPTION
`OrderStatus` expected some status values to be formatted in a snake_case fashion. Update mappings to use the correct casing (kebab-case).